### PR TITLE
Reserve ALL_CAPS for preprocessor defines; UpperCamelCase for all other constants

### DIFF
--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -3108,7 +3108,6 @@ body for explanations examples, and exceptions.
   `_p` for active high
 * Typedefs should be suffixed with `_t`
 * Multiple suffixes will not be separated with `_`. `n` should come first
-  `i`, `o`, or `io` last
 
 ### Language features
 

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -991,7 +991,6 @@ endmodule
 | \`define macros                                  | `ALL_CAPS`              |
 | Constants (parameters, localparams, enum values) | `UpperCamelCase`        |
 | Typedefs (including enums)                       | `lower_snake_case_t`    |
-| Enumerated value names                           | `UpperCamelCase`        |
 
 ### Constants
 


### PR DESCRIPTION
Rationale: The existing style guide gives some confusing guidance of when to use `ALL_CAPS` vs `UpperCamelCase` for `parameter`, `localparam`, and `enum` types. Simplified it to just two rules:

* Preprocessor definitions: always `ALL_CAPS`
* All other constants (`parameter`, `localparam`, `enum`, etc): always `UpperCamelCase`